### PR TITLE
#23에 작업

### DIFF
--- a/bubblit/assets/js/chatTestModule.js
+++ b/bubblit/assets/js/chatTestModule.js
@@ -79,34 +79,40 @@ class ChatTestModule extends React.Component {
                 // this.setState({
                 //     received: payload['body']
                 // })
+
+                var changes = { 'participants': this.state.participants, 'received': this.state.received }
+
                 let user_id = payload['user_id']
                 let msg = payload['body']
-                // 오류가 나면 콜백을 넣어야 할 듯?
-                if (!this.state.participants.includes(user_id)) {
-                    this.setState({
-                        participants: this.state.participants.concat(user_id)
-                    })
-                }
 
-                let find_user_id = (element) => {
-                    return element == user_id
-                }
+                changes = this.addNewMessageToChangesInplace(this.state, user_id, msg)
 
-                let user_idx = this.state.participants.findIndex(find_user_id)
-                let modified_received = this.state.received
-                if (modified_received[user_idx].length >= 5) {
-                    modified_received[user_idx].shift();
-                }
-
-                modified_received[user_idx].push(msg)
-                this.setState({
-                    received: modified_received
-                })
+                this.setState(changes)
             })
 
         })
-    }
 
+    }
+    addNewMessageToChangesInplace(changes, user_id, msg) {
+        let notInChanges = (changes.hasOwnProperty('participants') && changes['participants'].includes(user_id)) == false;
+        if (notInChanges) {
+            changes.participants = changes.participants.concat(user_id)
+        }
+
+        let find_user_id = (element) => {
+            return element == user_id
+        }
+
+        let user_idx = changes.participants.findIndex(find_user_id)
+        let modified_received = changes.received
+        if (modified_received[user_idx].length >= 5) {
+            modified_received[user_idx].shift();
+        }
+
+        changes.received[user_idx] = modified_received[user_idx].concat(msg)
+
+        return changes
+    }
     render() {
         return (
             <div className='roomarea'>

--- a/bubblit/assets/js/chatTestModule.js
+++ b/bubblit/assets/js/chatTestModule.js
@@ -69,6 +69,14 @@ class ChatTestModule extends React.Component {
                     this.state.channel.on("bubble_history", resp => {
                         console.log("버블히스토리납시오")
                         console.dir(resp.history)
+                        var changes = { 'participants': this.state.participants, 'received': { ...this.state.received } }
+                        resp.history.forEach(history => {
+                            let user_id = history['user_id']
+                            let msg = history['content']
+
+                            changes = this.addNewMessageToChangesInplace(this.state, user_id, msg)
+                        })
+                        this.setState(changes)
                     })
                 })
                 .receive("error", resp => { console.log("Unable to join", resp) })

--- a/bubblit/assets/js/chatTestModule.js
+++ b/bubblit/assets/js/chatTestModule.js
@@ -80,7 +80,7 @@ class ChatTestModule extends React.Component {
                 //     received: payload['body']
                 // })
 
-                var changes = { 'participants': this.state.participants, 'received': this.state.received }
+                var changes = { 'participants': this.state.participants, 'received': { ...this.state.received } }
 
                 let user_id = payload['user_id']
                 let msg = payload['body']

--- a/bubblit/assets/js/chatTestModule.js
+++ b/bubblit/assets/js/chatTestModule.js
@@ -33,7 +33,7 @@ class ChatTestModule extends React.Component {
         if (this.state.inputMessage == "") {
             return
         }
-        this.state.channel.push("new_msg", { body: this.state.inputMessage, nickname: this.state.nickname })
+        this.state.channel.push("new_msg", { body: this.state.inputMessage })
         this.setState({
             inputMessage: ""
         })
@@ -113,7 +113,7 @@ class ChatTestModule extends React.Component {
     render() {
         return (
             <div className='roomarea'>
-                <h2> 닉네임 입력. 반드시 닉네임 먼저 쓰고 아래 두개 할 것.</h2>
+                <h2> 닉네임 입력...은 이제 안씁니다.</h2>
                 <input
                     className="input"
                     type="text"

--- a/bubblit/assets/js/chatTestModule.js
+++ b/bubblit/assets/js/chatTestModule.js
@@ -16,16 +16,9 @@ class ChatTestModule extends React.Component {
             chooseChannel: "",
             channel: "",
             inputMessage: "",
-            nickname: "",
             participants: [],
             received: [[], [], [], [], [], []]
         }
-    }
-
-    handleNickname(event) {
-        this.setState({
-            nickname: event.target.value
-        })
     }
 
     handleInputMessageSubmit(event) {
@@ -61,7 +54,7 @@ class ChatTestModule extends React.Component {
                 .receive("ok", () => alert("기존 채널을 떠납니다!"))
         }
         this.setState({
-            channel: socket.channel(channelName, { nickname: this.state.nickname })
+            channel: socket.channel(channelName)
         }, () => {
             // 이해를 돕기 위한 console.log 분리
             let cur_channel = this.state.channel.join()
@@ -73,6 +66,10 @@ class ChatTestModule extends React.Component {
                     this.state.channel.on("presence_state", state => {
                         presences = Presence.syncState(presences, state)
                     })
+                    this.state.channel.on("bubble_history", resp => {
+                        console.log("버블히스토리납시오")
+                        console.dir(resp.history)
+                    })
                 })
                 .receive("error", resp => { console.log("Unable to join", resp) })
 
@@ -82,20 +79,20 @@ class ChatTestModule extends React.Component {
                 // this.setState({
                 //     received: payload['body']
                 // })
-                let nickname = payload['nickname']
+                let user_id = payload['user_id']
                 let msg = payload['body']
                 // 오류가 나면 콜백을 넣어야 할 듯?
-                if (!this.state.participants.includes(nickname)) {
+                if (!this.state.participants.includes(user_id)) {
                     this.setState({
-                        participants: this.state.participants.concat(nickname)
+                        participants: this.state.participants.concat(user_id)
                     })
                 }
 
-                let find_nickname = (element) => {
-                    return element == nickname
+                let find_user_id = (element) => {
+                    return element == user_id
                 }
 
-                let user_idx = this.state.participants.findIndex(find_nickname)
+                let user_idx = this.state.participants.findIndex(find_user_id)
                 let modified_received = this.state.received
                 if (modified_received[user_idx].length >= 5) {
                     modified_received[user_idx].shift();
@@ -113,13 +110,6 @@ class ChatTestModule extends React.Component {
     render() {
         return (
             <div className='roomarea'>
-                <h2> 닉네임 입력...은 이제 안씁니다.</h2>
-                <input
-                    className="input"
-                    type="text"
-                    value={this.state.nickname}
-                    onChange={this.handleNickname.bind(this)}
-                />
                 <form onSubmit={this.handleChooseChannelSubmit.bind(this)}>
                     <h2>채팅방 이름 작성</h2>
                     <input className="input"

--- a/bubblit/assets/js/socket.js
+++ b/bubblit/assets/js/socket.js
@@ -8,6 +8,8 @@
 // from the params if you are not using authentication.
 import { Socket } from "phoenix"
 
+console.log("주목!!!!!!!!!!!!!!!! token = " + window.userToken)
+
 let socket = new Socket("/socket", { params: { token: window.userToken } })
 
 // When you connect, you'll often need to authenticate the client.

--- a/bubblit/lib/bubblit/accounts/auth.ex
+++ b/bubblit/lib/bubblit/accounts/auth.ex
@@ -6,7 +6,9 @@ defmodule Bubblit.Accounts.Auth do
     user = repo.get_by(User, name: params["name"])
 
     case authenticate(user, params["password"]) do
-      true -> {:ok, user}
+      true ->
+        {:ok, user}
+
       error ->
         Util.log(inspect(error))
 
@@ -16,11 +18,11 @@ defmodule Bubblit.Accounts.Auth do
 
   defp authenticate(user, password) do
     if user do
-        case Encryption.validate_password(user, password) do
-          # 갑자기 email이?
-          {:ok, validated_user} -> true
-          {:error, _} -> nil
-        end
+      case Encryption.validate_password(user, password) do
+        # 갑자기 email이?
+        {:ok, _validated_user} -> true
+        {:error, _} -> nil
+      end
     else
       nil
     end

--- a/bubblit/lib/bubblit/bubble_rooms.ex
+++ b/bubblit/lib/bubblit/bubble_rooms.ex
@@ -140,6 +140,7 @@ defmodule Bubblit.BubbleRooms do
 
   """
   def get_room!(id), do: Repo.get!(Room, id)
+  def get_room(id), do: Repo.get(Room, id)
 
   @doc """
   Creates a room.

--- a/bubblit/lib/bubblit/bubble_rooms/bubble_log.ex
+++ b/bubblit/lib/bubblit/bubble_rooms/bubble_log.ex
@@ -2,6 +2,7 @@ defmodule Bubblit.BubbleRooms.BubbleLog do
   use Ecto.Schema
   import Ecto.Changeset
 
+  @derive {Jason.Encoder, only: [:id, :content, :room_id, :user_id, :inserted_at]}
   schema "bubble_logs" do
     field :content, :string
     field :room_id, :integer

--- a/bubblit/lib/bubblit/db/db.ex
+++ b/bubblit/lib/bubblit/db/db.ex
@@ -10,6 +10,24 @@ defmodule Bubblit.Db do
     room_record
   end
 
+  def get_or_create_room(id, host_user_id) do
+    room_db = Bubblit.BubbleRooms.get_room(id)
+
+    if room_db == nil do
+      create_room("#{host_user_id} 번 id 유저의 임시 방(#{id}번)이다냥!", host_user_id)
+    else
+      room_db
+    end
+  end
+
+  def load_room(title, host_user_id) do
+    # 일단 Default 세팅으로 가보자.
+    attrs = %{title: title, host_user_id: host_user_id, config_value: ""}
+    {:ok, room_record} = Bubblit.BubbleRooms.create_room(attrs)
+
+    room_record
+  end
+
   def change_room_config(room_record, config_value) do
     # 일단 Default 세팅으로 가보자.
     attrs = %{config_value: config_value}

--- a/bubblit/lib/bubblit/room/room_monitor.ex
+++ b/bubblit/lib/bubblit/room/room_monitor.ex
@@ -19,20 +19,12 @@ defmodule Bubblit.Room.Monitor do
     GenServer.call(via_tuple(room_id), :get_messages)
   end
 
-  def get_record_state_id(id) do
-    Util.log("get_record_state_id #{id}")
-    get_record_state(id) |> Map.get(id)
   end
 
-  def get_record_state(id) do
-    Util.log("get_record_state #{id}")
-    Agent.get(__MODULE__, fn state -> get_record_state(state, id) end)
+
   end
 
-  def step_record_update(id, step_record) do
-    Util.log("step_record_update #{id} #{step_record}")
-    Agent.get_and_update(__MODULE__, fn state -> step_record_update(state, id, step_record) end)
-  end
+  # 여기 아래는 참고용
 
   def get_record_state(state, _id) do
     state
@@ -57,5 +49,20 @@ defmodule Bubblit.Room.Monitor do
     # Util.log("record #{inspect(record)}가 갱신.#{inspect(new_record)}로 됨여.")
 
     {state, Map.put(state, id, step_record)}
+  end
+
+  def get_record_state_id(id) do
+    Util.log("get_record_state_id #{id}")
+    get_record_state(id) |> Map.get(id)
+  end
+
+  def get_record_state(id) do
+    Util.log("get_record_state #{id}")
+    Agent.get(__MODULE__, fn state -> get_record_state(state, id) end)
+  end
+
+  def step_record_update(id, step_record) do
+    Util.log("step_record_update #{id} #{step_record}")
+    Agent.get_and_update(__MODULE__, fn state -> step_record_update(state, id, step_record) end)
   end
 end

--- a/bubblit/lib/bubblit/room/room_process.ex
+++ b/bubblit/lib/bubblit/room/room_process.ex
@@ -4,7 +4,13 @@ defmodule Bubblit.Room.Process do
   require Util
 
   def start_link(init_arg) do
-    Supervisor.start_link(__MODULE__, init_arg)
+    Util.log("#{inspect(init_arg)} 가지고 #{__MODULE__} 을 시작")
+    [room_id: room_id] = init_arg
+    Supervisor.start_link(__MODULE__, init_arg, name: via_tuple(room_id))
+  end
+
+  defp via_tuple(room_id) do
+    {:via, Bubblit.Room.Registry, {:room_process, room_id}}
   end
 
   def init(init_arg) do

--- a/bubblit/lib/bubblit_web/channels/presence.ex
+++ b/bubblit/lib/bubblit_web/channels/presence.ex
@@ -68,6 +68,7 @@ defmodule BubblitWeb.Presence do
   information, while maintaining the required `:metas` field from the
   original presence data.
   """
-  use Phoenix.Presence, otp_app: :bubblit,
-                        pubsub_server: Bubblit.PubSub
+  use Phoenix.Presence,
+    otp_app: :bubblit,
+    pubsub_server: Bubblit.PubSub
 end

--- a/bubblit/lib/bubblit_web/channels/room_channel.ex
+++ b/bubblit/lib/bubblit_web/channels/room_channel.ex
@@ -20,8 +20,8 @@ defmodule BubblitWeb.RoomChannel do
   end
 
   # 그냥 메세지 브로드캐스트할때 닉네임 추가했음.
-  def handle_in("new_msg", %{"body" => body, "nickname" => nickname}, socket) do
-    broadcast!(socket, "new_msg", %{body: body, nickname: nickname})
+  def handle_in("new_msg", %{"body" => body}, socket) do
+    broadcast!(socket, "new_msg", %{body: body, nickname: socket.assigns.user.name})
 
     {:noreply, socket}
   end

--- a/bubblit/lib/bubblit_web/channels/room_channel.ex
+++ b/bubblit/lib/bubblit_web/channels/room_channel.ex
@@ -48,7 +48,7 @@ defmodule BubblitWeb.RoomChannel do
   def handle_in("new_msg", %{"body" => body}, socket) do
     Bubblit.Room.Monitor.add_message(socket.assigns.room_record.id, socket.assigns.user_id, body)
 
-    broadcast!(socket, "new_msg", %{body: body, nickname: socket.assigns.user.name})
+    broadcast!(socket, "new_msg", %{body: body, user_id: socket.assigns.user_id})
 
     {:noreply, socket}
   end

--- a/bubblit/lib/bubblit_web/channels/room_channel.ex
+++ b/bubblit/lib/bubblit_web/channels/room_channel.ex
@@ -21,6 +21,8 @@ defmodule BubblitWeb.RoomChannel do
 
   # 그냥 메세지 브로드캐스트할때 닉네임 추가했음.
   def handle_in("new_msg", %{"body" => body}, socket) do
+    Bubblit.Db.create_bubble_log(1, socket.assigns.user_id, body)
+
     broadcast!(socket, "new_msg", %{body: body, nickname: socket.assigns.user.name})
 
     {:noreply, socket}

--- a/bubblit/lib/bubblit_web/channels/room_channel.ex
+++ b/bubblit/lib/bubblit_web/channels/room_channel.ex
@@ -4,24 +4,49 @@ defmodule BubblitWeb.RoomChannel do
 
   require Logger
 
-  def join("room:" <> _room_name, _params, socket) do
-    send(self(), :after_join)
-    {:ok, socket}
+  def join("room:" <> room_id, _params, socket) do
+    Logger.info("lobby room joined #{room_id} #{inspect(socket)}")
+
+    case Integer.parse(room_id) do
+      {room_id, _remainer} ->
+        room_record = Bubblit.Db.get_or_create_room(room_id, socket.assigns.user_id)
+        Bubblit.Room.DynamicSupervisor.start_child(room_id)
+        send(self(), :after_join)
+
+        socket =
+          assign(socket, :room_record, room_record) |> assign(:id, inspect(socket.transport_pid))
+
+        Logger.info("user id #{socket.assigns.user_id} joined to room id #{room_id}.")
+
+        {:ok, %{body: "어서와"}, socket}
+
+      :error ->
+        {:error, %{reason: "invalid channel name"}}
+    end
   end
 
   def handle_info(:after_join, socket) do
+    Logger.info(
+      "user id #{socket.assigns.user_id} after join to room id #{socket.assigns.room_record.id}."
+    )
+
     {:ok, _} =
       Presence.track(socket, socket.assigns.user_id, %{
         online_at: inspect(System.system_time(:second))
       })
 
     push(socket, "presence_state", Presence.list(socket))
+
+    bubble_history = Bubblit.Room.Monitor.get_messages(socket.assigns.room_record.id)
+
+    push(socket, "bubble_history", %{history: bubble_history})
+
     {:noreply, socket}
   end
 
   # 그냥 메세지 브로드캐스트할때 닉네임 추가했음.
   def handle_in("new_msg", %{"body" => body}, socket) do
-    Bubblit.Db.create_bubble_log(1, socket.assigns.user_id, body)
+    Bubblit.Room.Monitor.add_message(socket.assigns.room_record.id, socket.assigns.user_id, body)
 
     broadcast!(socket, "new_msg", %{body: body, nickname: socket.assigns.user.name})
 

--- a/bubblit/lib/bubblit_web/controllers/session_controller.ex
+++ b/bubblit/lib/bubblit_web/controllers/session_controller.ex
@@ -13,7 +13,7 @@ defmodule BubblitWeb.SessionController do
     case Auth.login(auth_params, Repo) do
       {:ok, user} ->
         conn
-        |> put_session(:current_user_id, user.id)
+        |> BubblitWeb.UserController.login_user(user)
         |> put_flash(:info, "Signed in successfully.")
         |> redirect(to: Routes.page_path(conn, :index))
 
@@ -26,7 +26,7 @@ defmodule BubblitWeb.SessionController do
 
   def delete(conn, _params) do
     conn
-    |> delete_session(:current_user_id)
+    |> BubblitWeb.UserController.logout_user()
     |> put_flash(:info, "Signed out successfully.")
     |> redirect(to: Routes.session_path(conn, :new))
   end

--- a/bubblit/lib/bubblit_web/controllers/user_controller.ex
+++ b/bubblit/lib/bubblit_web/controllers/user_controller.ex
@@ -13,12 +13,26 @@ defmodule BubblitWeb.UserController do
     case Accounts.create_user(user_params) do
       {:ok, user} ->
         conn
-        |> put_session(:current_user_id, user.id)
+        |> login_user(user)
         |> put_flash(:info, "Signed up successfully.")
         |> redirect(to: Routes.page_path(conn, :index))
-    {:error, %Ecto.Changeset{} = changeset} ->
-      render(conn, "new.html", changeset: changeset)
+
+      {:error, %Ecto.Changeset{} = changeset} ->
+        render(conn, "new.html", changeset: changeset)
     end
   end
 
+  def login_user(conn, user) do
+    Util.log("login user. #{inspect(conn.assigns)}")
+
+    conn
+    |> put_session(:current_user_id, user.id)
+    |> put_session(:current_user, user)
+  end
+
+  def logout_user(conn) do
+    conn
+    |> delete_session(:current_user_id)
+    |> delete_session(:current_user)
+  end
 end

--- a/bubblit/lib/bubblit_web/plugs/auth.ex
+++ b/bubblit/lib/bubblit_web/plugs/auth.ex
@@ -9,13 +9,13 @@ defmodule BubblitWeb.Plugs.Auth do
   def call(conn, _opts) do
     if user_id = Plug.Conn.get_session(conn, :current_user_id) do
       current_user = Accounts.get_user!(user_id)
+
       conn
-        |> assign(:current_user, current_user)
+      |> assign(:current_user, current_user)
     else
       conn
-        |> redirect(to: "/login")
-        |> halt()
+      |> redirect(to: "/login")
+      |> halt()
     end
   end
-
 end

--- a/bubblit/lib/bubblit_web/plugs/guest.ex
+++ b/bubblit/lib/bubblit_web/plugs/guest.ex
@@ -10,6 +10,7 @@ defmodule BubblitWeb.Plugs.Guest do
       |> redirect(to: BubblitWeb.Router.Helpers.page_path(conn, :index))
       |> halt()
     end
+
     conn
   end
 end

--- a/bubblit/lib/bubblit_web/plugs/guest.ex
+++ b/bubblit/lib/bubblit_web/plugs/guest.ex
@@ -9,8 +9,8 @@ defmodule BubblitWeb.Plugs.Guest do
       conn
       |> redirect(to: BubblitWeb.Router.Helpers.page_path(conn, :index))
       |> halt()
+    else
+      conn
     end
-
-    conn
   end
 end

--- a/bubblit/lib/bubblit_web/router.ex
+++ b/bubblit/lib/bubblit_web/router.ex
@@ -1,12 +1,16 @@
 defmodule BubblitWeb.Router do
   use BubblitWeb, :router
 
+  require Util
+
   pipeline :browser do
     plug(:accepts, ["html"])
     plug(:fetch_session)
     plug(:fetch_flash)
     plug(:protect_from_forgery)
     plug(:put_secure_browser_headers)
+    plug BubblitWeb.Plugs.Auth
+    plug(:put_user_token)
   end
 
   pipeline :api do
@@ -27,12 +31,20 @@ defmodule BubblitWeb.Router do
 
     delete "/logout", SessionController, :delete
 
-    #왠진 모르겠는데 이게 없으면 그냥 index가 안되더라...
+    # 왠진 모르겠는데 이게 없으면 그냥 index가 안되더라...
     get "/main", PageController, :index
 
     get "/*path", PageController, :index
   end
 
+  defp put_user_token(conn, _) do
+    if current_user = conn.assigns[:current_user] do
+      token = Phoenix.Token.sign(conn, "user salt", current_user.id)
+      assign(conn, :user_token, token)
+    else
+      conn
+    end
+  end
 
   # Other scopes may use custom stacks.
   # scope "/api", BubblitWeb do

--- a/bubblit/lib/bubblit_web/router.ex
+++ b/bubblit/lib/bubblit_web/router.ex
@@ -9,8 +9,6 @@ defmodule BubblitWeb.Router do
     plug(:fetch_flash)
     plug(:protect_from_forgery)
     plug(:put_secure_browser_headers)
-    plug BubblitWeb.Plugs.Auth
-    plug(:put_user_token)
   end
 
   pipeline :api do
@@ -27,7 +25,7 @@ defmodule BubblitWeb.Router do
   end
 
   scope "/", BubblitWeb do
-    pipe_through [:browser, BubblitWeb.Plugs.Auth]
+    pipe_through [:browser, BubblitWeb.Plugs.Auth, :put_user_token]
 
     delete "/logout", SessionController, :delete
 

--- a/bubblit/lib/bubblit_web/templates/layout/app.html.eex
+++ b/bubblit/lib/bubblit_web/templates/layout/app.html.eex
@@ -9,6 +9,8 @@
     <%= csrf_meta_tag() %>
   </head>
   <body>
+      <script>console.log("sdfdsfsdfds");</script>
+      <script>window.userToken = "<%= assigns[:user_token] %>";</script>
     <nav>
       <div class="nav-wrapper primary-dark-color">
         <a href="/" class="brand-logo">Bubblit Login Page</a>
@@ -27,6 +29,7 @@
       </div>
     </nav>
     <%= render @view_module, @view_template, assigns %>
+      <%# <%= inspect(assigns) %> %>
       <script type="text/javascript" src="<%= Routes.static_path(@conn, "/js/app.js") %>"></script>
   </body>
 </html>

--- a/bubblit/lib/bubblit_web/views/session_view.ex
+++ b/bubblit/lib/bubblit_web/views/session_view.ex
@@ -1,4 +1,3 @@
 defmodule BubblitWeb.SessionView do
   use BubblitWeb, :view
-
 end

--- a/bubblit/priv/repo/migrations/20200406081801_create_bubble_logs.exs
+++ b/bubblit/priv/repo/migrations/20200406081801_create_bubble_logs.exs
@@ -9,6 +9,5 @@ defmodule Bubblit.Repo.Migrations.CreateBubbleLogs do
 
       timestamps()
     end
-
   end
 end

--- a/bubblit/priv/repo/migrations/20200406081811_create_rooms.exs
+++ b/bubblit/priv/repo/migrations/20200406081811_create_rooms.exs
@@ -11,6 +11,5 @@ defmodule Bubblit.Repo.Migrations.CreateRooms do
 
       timestamps()
     end
-
   end
 end

--- a/bubblit/priv/repo/migrations/20200406081833_create_users.exs
+++ b/bubblit/priv/repo/migrations/20200406081833_create_users.exs
@@ -7,6 +7,5 @@ defmodule Bubblit.Repo.Migrations.CreateUsers do
 
       timestamps()
     end
-
   end
 end

--- a/bubblit/priv/repo/migrations/20200419175050_create_unique_index_user_table_name_column.exs
+++ b/bubblit/priv/repo/migrations/20200419175050_create_unique_index_user_table_name_column.exs
@@ -1,0 +1,7 @@
+defmodule Bubblit.Repo.Migrations.CreateUniqueIndexUserTableNameColumn do
+  use Ecto.Migration
+
+  def change do
+    create unique_index(:users, [:name])
+  end
+end

--- a/bubblit/test/bubblit/bubble_rooms_test.exs
+++ b/bubblit/test/bubblit/bubble_rooms_test.exs
@@ -42,7 +42,10 @@ defmodule Bubblit.BubbleRoomsTest do
 
     test "update_bubble_log/2 with valid data updates the bubble_log" do
       bubble_log = bubble_log_fixture()
-      assert {:ok, %BubbleLog{} = bubble_log} = BubbleRooms.update_bubble_log(bubble_log, @update_attrs)
+
+      assert {:ok, %BubbleLog{} = bubble_log} =
+               BubbleRooms.update_bubble_log(bubble_log, @update_attrs)
+
       assert bubble_log.content == "some updated content"
       assert bubble_log.room_id == 43
       assert bubble_log.user_id == 43
@@ -50,7 +53,10 @@ defmodule Bubblit.BubbleRoomsTest do
 
     test "update_bubble_log/2 with invalid data returns error changeset" do
       bubble_log = bubble_log_fixture()
-      assert {:error, %Ecto.Changeset{}} = BubbleRooms.update_bubble_log(bubble_log, @invalid_attrs)
+
+      assert {:error, %Ecto.Changeset{}} =
+               BubbleRooms.update_bubble_log(bubble_log, @invalid_attrs)
+
       assert bubble_log == BubbleRooms.get_bubble_log!(bubble_log.id)
     end
 
@@ -69,9 +75,27 @@ defmodule Bubblit.BubbleRoomsTest do
   describe "rooms" do
     alias Bubblit.BubbleRooms.Room
 
-    @valid_attrs %{config_value: "some config_value", host_name: "some host_name", is_anonymous: true, is_private: true, title: "some title"}
-    @update_attrs %{config_value: "some updated config_value", host_name: "some updated host_name", is_anonymous: false, is_private: false, title: "some updated title"}
-    @invalid_attrs %{config_value: nil, host_name: nil, is_anonymous: nil, is_private: nil, title: nil}
+    @valid_attrs %{
+      config_value: "some config_value",
+      host_name: "some host_name",
+      is_anonymous: true,
+      is_private: true,
+      title: "some title"
+    }
+    @update_attrs %{
+      config_value: "some updated config_value",
+      host_name: "some updated host_name",
+      is_anonymous: false,
+      is_private: false,
+      title: "some updated title"
+    }
+    @invalid_attrs %{
+      config_value: nil,
+      host_name: nil,
+      is_anonymous: nil,
+      is_private: nil,
+      title: nil
+    }
 
     def room_fixture(attrs \\ %{}) do
       {:ok, room} =

--- a/bubblit/test/bubblit_web/controllers/user_controller_test.exs
+++ b/bubblit/test/bubblit_web/controllers/user_controller_test.exs
@@ -4,7 +4,10 @@ defmodule BubblitWeb.UserControllerTest do
   alias Bubblit.Accounts
 
   @create_attrs %{encrypted_password: "some encrypted_password", name: "some name"}
-  @update_attrs %{encrypted_password: "some updated encrypted_password", name: "some updated name"}
+  @update_attrs %{
+    encrypted_password: "some updated encrypted_password",
+    name: "some updated name"
+  }
   @invalid_attrs %{encrypted_password: nil, name: nil}
 
   def fixture(:user) do
@@ -75,6 +78,7 @@ defmodule BubblitWeb.UserControllerTest do
     test "deletes chosen user", %{conn: conn, user: user} do
       conn = delete(conn, Routes.user_path(conn, :delete, user))
       assert redirected_to(conn) == Routes.user_path(conn, :index)
+
       assert_error_sent 404, fn ->
         get(conn, Routes.user_path(conn, :show, user))
       end


### PR DESCRIPTION
db 제약이 추가되었으므로 그냥 마이그레이션하면 안될 수 있습니다. `mix ecto.drop` `mix ecto.create` `mix ecto.migrate` 해주세여 ㅎ

### 세줄요약

 - 토큰 인증 추가.
 - 이제 채팅방별로 process가 뜨고 대화도 저장함
 - 그렇기 때문에 나중에 들어간사람도 대화 볼 수 있음. ㅎ


@RE-A 프론트 규칙이 좀 바뀌었읍니다
 - 채팅방 이름 말고 채팅방 번호를 받게 설정되었읍니다
 - 이제 유저들이 닉네임말고 id로 대화합니다. 닉네임은 서버에서 저장하고있으나 지금 어떻게 내려줄지 고민중. 요상담(要相談)
 - 일부 코드 리팩토링함. setState 관련해서는 나도 확신이 없으니 리팩토링 한 것 관련해서 이야기를 나눠보고 싶음
 - token을 주고 받는 과정에서 프론트에 token 정보를 좀 저장하므로 이것에 대한 이해를 해야할 듯
 - socket보니까 내부에서 connect 하던데, 이제 그렇게 하면 안됨. (token이 없으면 socket을 열지 말아야함.)

@Kynel 이제 채팅 히스토리를 잘 받아옴으로 재료는 충분합니다.
 - 준호 코드 기반으로 표시는 하게 해줬음
 - 이걸 잘 store에 저장해서 잘 표시되게 하면 좋을것같음.
 - 여전히 유저 닉네임을 표시하는 부분이 없으므로 이 부분은 준호랑 같이 3명이서 어캐할지에 대한 간단한 이해를 하고 넘어가는게 중요할듯

차후 문제로는 eex 를 어떻게 react랑 섞냐인데, 섞어보고 안되면 한쪽으로 가고 (eex는 편한것뿐이지 다 react로 가능함. api 써버 식으로.) 그런것에 대한 정보 조사가 필요하다. 이거 발표때 써먹으면 다음주까지 뚝딱일듯.

