### PR TITLE
#52 유저 정보를 이용해 유저 이름을 표시하게 함

### DIFF
--- a/bubblit/assets/js/Component/ChatBox.js
+++ b/bubblit/assets/js/Component/ChatBox.js
@@ -152,7 +152,7 @@ export default class ChatBox extends Component {
                     }}
                 >
                     <div className='general'>
-                        <h2>user_id: {this.props.temp}</h2>
+                        <h2>{this.props.name}</h2>
                         <Scrollbars
                             className='scrollbar'
                             ref={this.scrollbarRef}

--- a/bubblit/assets/js/Component/ChatModule.js
+++ b/bubblit/assets/js/Component/ChatModule.js
@@ -41,19 +41,27 @@ export default class ChatModule extends Component {
                         let msg = history['content'];
                         this.addMessageInChanges(changes, user_id, msg);
                     })
+
+                    changes['users'] = payload.users;
                     //여기에서 보내는 함수 호출함
                     this.props.sendChanges(changes);
                 })
-                })
-            .receive('error', response => { console.log('Unable to join', response) })
-        // new_msg 받을때 처리
-                this.props.channel.on("new_msg", payload => {
-            var changes = { 'participants': this.props.participants, 'contents': { ...this.props.contents } };
-                    let user_id = payload['user_id'];
-                    let msg = payload['body'];
-            changes = this.addMessageInChanges(changes, user_id, msg);
+                this.props.channel.on('user_join', payload => {
+                    console.log('user_join', payload);
+                    var changes = { 'participants': this.props.participants, 'contents': { ...this.props.contents }, 'users': { ...this.props.users } };
+                    changes['users'][payload.user_id] = { id: payload.uesr_id, name: payload.user_name };
                     this.props.sendChanges(changes);
                 })
+                this.props.channel.on("new_msg", payload => {
+                    var changes = { 'participants': this.props.participants, 'contents': { ...this.props.contents }, 'users': this.props.users };
+                    let user_id = payload['user_id'];
+                    let msg = payload['body'];
+                    this.addMessageInChanges(changes, user_id, msg);
+                    this.props.sendChanges(changes);
+                })
+            })
+            .receive('error', response => { console.log('Unable to join', response) })
+        // new_msg 받을때 처리
         //this.props.channel.push('new_msg', { body: '테스트 메세지임니담', nickname: 'tester' });
     }
 
@@ -81,12 +89,13 @@ export default class ChatModule extends Component {
 
     chatboxRenderer() {
         var message = [];
-        var classNames = this.props.participants;
-        for (var i = 0; i < classNames.length; i++) {
+        var participant = this.props.participants;
+        for (var i = 0; i < participant.length; i++) {
             let temp = i;
-            //classNames.forEach(name => {
+            let user_id = participant[i];
+            let user = this.props.users[user_id];
             message.push(
-                <ChatBox key={i} temp={temp} contents={this.props.contents}></ChatBox>
+                <ChatBox key={i} temp={temp} name={user.name} contents={this.props.contents}></ChatBox>
             )
         }
         return message

--- a/bubblit/assets/js/Component/ChatModule.js
+++ b/bubblit/assets/js/Component/ChatModule.js
@@ -8,8 +8,7 @@ import '../../css/chatModule.css'
 export default class ChatModule extends Component {
     constructor(props) {
         super(props);
-        console.log(window.innerWidth)
-        console.log(window.innerHeight)
+        console.log("chatmodule width, height", window.innerWidth, window.innerHeight)
         this.state = {
             // 방에 나갓다 들어와도 커스텀값이 유지되도록 state로 빼봣음, store로 옮기거나, 수정예정
             width: [400, 400, 400, 400, 400, 400],
@@ -36,7 +35,7 @@ export default class ChatModule extends Component {
                 // bubble_history 받을때 처리
                 this.props.channel.on('room_history', payload => {
                     var changes = { 'participants': this.props.participants, 'contents': { ...this.props.contents } };
-                    console.log(payload);
+                    console.log('room_history', payload);
                     payload.bubble_history.reverse().forEach(history => {
                         let user_id = history['user_id'];
                         let msg = history['content'];
@@ -45,16 +44,16 @@ export default class ChatModule extends Component {
                     //여기에서 보내는 함수 호출함
                     this.props.sendChanges(changes);
                 })
-            })
+                })
             .receive('error', response => { console.log('Unable to join', response) })
         // new_msg 받을때 처리
-        this.props.channel.on("new_msg", payload => {
+                this.props.channel.on("new_msg", payload => {
             var changes = { 'participants': this.props.participants, 'contents': { ...this.props.contents } };
-            let user_id = payload['user_id'];
-            let msg = payload['body'];
+                    let user_id = payload['user_id'];
+                    let msg = payload['body'];
             changes = this.addMessageInChanges(changes, user_id, msg);
-            this.props.sendChanges(changes);
-        })
+                    this.props.sendChanges(changes);
+                })
         //this.props.channel.push('new_msg', { body: '테스트 메세지임니담', nickname: 'tester' });
     }
 

--- a/bubblit/assets/js/Container/ChatModule.js
+++ b/bubblit/assets/js/Container/ChatModule.js
@@ -5,6 +5,7 @@ function mapReduxStateToReactProps(state) {
     return {
         channel: state.channel,
         userName: state.userName,
+        users: state.users,
         contents: state.contents,
         participants: state.participants,
     }
@@ -13,7 +14,7 @@ function mapReduxStateToReactProps(state) {
 function mapReduxDispatchToReactProps(dispatch) {
     return {
         sendChanges: function (changes) {
-            dispatch({ type: 'CHAT', contents: changes.contents, participants: changes.participants })
+            dispatch({ type: 'CHAT', contents: changes.contents, participants: changes.participants, users: changes.users })
         },
         exitRoom: function (channel) {
             //channel.push('new_msg', { body: '테스트 메세지임니담' });

--- a/bubblit/assets/js/store.js
+++ b/bubblit/assets/js/store.js
@@ -21,11 +21,11 @@ export default createStore(function (state, action) {
 
             // { id: 0, title: '1st Room', host: 'kynel', isPrivate: 'O', limit: 10, current: 6 },
             roomList: [],
-            current_room_id: 0, 
+            current_room_id: 0,
 
             //ChatModule
             contents: [[], [], [], [], [], []],
-            participants: [],
+            participants: []
         }
         return state;
     }
@@ -38,11 +38,12 @@ export default createStore(function (state, action) {
             ...state,
             current_room_id: action.room_id,
             mode: room.title,
+            users: action.users,
             channel: state.socket.channel('room:' + room.id, { nickname: state.userName })
         }
     }
     if (action.type === 'CHAT') {
-        return { ...state, contents: action.contents, participants: action.participants }
+        return { ...state, contents: action.contents, participants: action.participants, users: action.users }
     }
     if (action.type === 'REFRESH_ROOM_LIST') {
         //channel 구독해지 및 state 초기화

--- a/bubblit/lib/bubblit/accounts/user.ex
+++ b/bubblit/lib/bubblit/accounts/user.ex
@@ -3,6 +3,7 @@ defmodule Bubblit.Accounts.User do
   import Ecto.Changeset
   alias Bubblit.Accounts.{User, Encryption}
 
+  @derive {Jason.Encoder, only: [:id, :name]}
   schema "users" do
     field :encrypted_password, :string
     field :name, :string

--- a/bubblit/lib/bubblit/bubble_rooms.ex
+++ b/bubblit/lib/bubblit/bubble_rooms.ex
@@ -6,6 +6,7 @@ defmodule Bubblit.BubbleRooms do
   import Ecto.Query, warn: false
   alias Bubblit.Repo
 
+  alias Bubblit.Accounts.User
   alias Bubblit.BubbleRooms.BubbleLog
 
   @doc """
@@ -24,7 +25,11 @@ defmodule Bubblit.BubbleRooms do
   def list_bubble_logs(room_id) do
     query =
       from l in BubbleLog,
-        where: l.room_id == ^room_id
+        preload: [:user],
+        join: u in User,
+        on: u.id == l.user_id,
+        where: l.room_id == ^room_id,
+        select: {l, u}
 
     Repo.all(query)
   end

--- a/bubblit/lib/bubblit/room/room_monitor.ex
+++ b/bubblit/lib/bubblit/room/room_monitor.ex
@@ -6,9 +6,11 @@ defmodule Bubblit.Room.Monitor do
     Util.log(" #{__MODULE__} #{inspect(initial_state)} 가 실행됩니다.")
 
     # 역순 저장임.
-    history = Bubblit.Db.read_bubble_log(room_id) |> Enum.reverse()
+    {history, users} = Bubblit.Db.read_bubble_log(room_id) |> Enum.reverse() |> Enum.unzip()
 
-    initial_state = %{history: history, tab_action_dic: %{}, room_id: room_id}
+    users = users |> Enum.map(fn user -> {user.id, user} end) |> Enum.into(%{})
+
+    initial_state = %{history: history, users: users, tab_action_dic: %{}, room_id: room_id}
     Agent.start_link(fn -> initial_state end, name: via_tuple(room_id))
   end
 
@@ -20,28 +22,22 @@ defmodule Bubblit.Room.Monitor do
     Agent.update(via_tuple(room_id), fn state -> handle_add_message(state, user_id, message) end)
   end
 
-  def get_messages(room_id) do
-    Agent.get(via_tuple(room_id), fn state -> handle_get_messages(state) end)
+  def add_user(room_id, user_id, user) do
+    Agent.update(via_tuple(room_id), fn state -> handle_add_user(state, user_id, user) end)
   end
 
   def add_tab_action(room_id, user_id, type, message) do
-    Agent.update(via_tuple(room_id), fn state -> handle_add_tab_action(state, user_id, type, message) end)
+    Agent.update(via_tuple(room_id), fn state ->
+      handle_add_tab_action(state, user_id, type, message)
+    end)
   end
 
-  def get_tab_actions(room_id) do
-    Agent.get(via_tuple(room_id), fn state -> handle_get_tab_actions(state) end)
-  end
-
-  def handle_get_messages(state) do
-    Map.get(state, :history, [])
-  end
-
-  def handle_get_tab_actions(state) do
-    Map.get(state, :tab_action_dic, %{})
+  def get_after_join(room_id) do
+    Agent.get(via_tuple(room_id), fn state -> handle_get_after_join(state) end)
   end
 
   def handle_add_message(state, user_id, message) do
-    Util.log("user_id #{user_id} add_message #{message}")
+    Util.log("room#{state.room_id} user_id #{user_id} add_message #{message}")
     {:ok, bubble} = Bubblit.Db.create_bubble_log(state.room_id, user_id, message)
     history = [bubble | Map.get(state, :history, [])]
 
@@ -49,10 +45,36 @@ defmodule Bubblit.Room.Monitor do
   end
 
   def handle_add_tab_action(state, user_id, tab_action_type, tab_action_body) do
-    Util.log("user_id #{user_id} add_tab_action type #{tab_action_type} body #{tab_action_body}")
-    tab_action_dic = Map.put(state.tab_action_dic, tab_action_type, %{user_id: user_id, body: tab_action_body})
+    Util.log("room#{state.room_id} user_id #{user_id} add_tab_action type #{tab_action_type} body #{tab_action_body}")
+
+    tab_action_dic =
+      Map.put(state.tab_action_dic, tab_action_type, %{user_id: user_id, body: tab_action_body})
 
     Map.put(state, :tab_action_dic, tab_action_dic)
+  end
+
+  def handle_add_user(state, user_id, user) do
+    Util.log("room#{state.room_id} user_id #{user_id} added")
+
+    refresh_user(state, user_id, user)
+  end
+
+  def handle_get_after_join(state) do
+    %{
+      bubble_history: Map.get(state, :history, []),
+      users: Map.get(state, :users, []),
+      tab_action_history: Map.get(state, :tab_action_dic, %{})
+    }
+  end
+
+  def refresh_user(state, user_id, user) do
+    if Map.has_key?(state[:users], user_id) do
+      state
+    else
+      Util.log("add new user information to monitor #{user_id}")
+      users = Map.put(state[:users], user_id, user)
+      Map.put(state, :users, users)
+    end
   end
 
   # 여기 아래는 참고용


### PR DESCRIPTION
백엔드  기본 아이디어
 - 처음 뜰때는 DB에서, 그 이후에는 그 다음에 들어오는 사람들정보로 그걸 채움. (새로 DB에서 긁어오지 않음) - 이거 발표할만한듯?

프론트도비슷
- after_join 에 처음 받아야할걸받음 (bubble log, tab actions , users)

그래서 이름 잘 표시되게 함.

근데 코드가 매우 스파게티임. 리팩토링 해보려다가 나 혼자 하는것에 대한 한계를 느끼고 멈춤. 이 부분 추가적인 기능구현 들어가기전에 리팩토링이 시급해보임.