### PR TITLE
#95 ENTER CHAT 리팩토링 및 기능개선과 추가

### DIFF
--- a/bubblit/assets/css/lobby.css
+++ b/bubblit/assets/css/lobby.css
@@ -8,6 +8,10 @@
     font-size: 4em;
 }
 
+.room-entered {
+    background-color: salmon;
+}
+
 .table-cell-text {
     font: outline;
     font-weight: bold;

--- a/bubblit/assets/js/Component/ChatModule.js
+++ b/bubblit/assets/js/Component/ChatModule.js
@@ -5,7 +5,6 @@ import { Scrollbars, scrollToBottom } from 'react-custom-scrollbars';
 import ChatBox from './ChatBox'
 import '../../css/chatModule.css'
 import { Link } from 'react-router-dom';
-import { Presence } from "phoenix"
 
 //const DEF_CHATBOX_POS = { x: [0, 450, 0, 450, 0, 450], y: [0, 0, 300, 300, 600, 600] }
 const INPUTSPACE_RELATIVE_POS = { x: 0, y: 0.8 };

--- a/bubblit/assets/js/Component/Lobby.js
+++ b/bubblit/assets/js/Component/Lobby.js
@@ -44,7 +44,7 @@ export default class Lobby extends Component {
                     <Link to="/room"><Button secondary key={"active" + i} action={{ index: i }} onClick={function (e, data) {
                         var room_id = _roomList[data.action.index].id;
                         // [TODO] enterRoom 대신 room_id만 set해주는 redux 함수를 만들어야 할듯.
-                        this.props.enterRoom(room_id);
+                        this.props.setRoomID(room_id);
                     }.bind(this)}>join</Button>
                     </Link>
                 )

--- a/bubblit/assets/js/Component/Lobby.js
+++ b/bubblit/assets/js/Component/Lobby.js
@@ -30,7 +30,6 @@ export default class Lobby extends Component {
 
     render() {
         var content = [];
-        var _props = this.props;
         var _roomList = this.props.roomList;
         var i = 0;
         while (i < _roomList.length) {

--- a/bubblit/assets/js/Component/Lobby.js
+++ b/bubblit/assets/js/Component/Lobby.js
@@ -10,7 +10,8 @@ export default class Lobby extends Component {
     componentDidMount() {
 
         var _userName = document.getElementById('current-username').innerHTML
-        this.props.setUserName(_userName)
+        var _userid = document.getElementById('current-userid').innerHTML
+        this.props.setUserData(_userName, _userid)
         // then 안에서 this를 쓰기위함...
         var self = this;
         axios.get('/api/room/get/')
@@ -48,16 +49,28 @@ export default class Lobby extends Component {
                 )
             }
             var row = [
-                { key: "id", value: _roomList[i].id },
-                { key: "title", value: _roomList[i].title },
-                // { key: "limit", value: _roomList[i].limit },
-                // { key: "current", value: _roomList[i].current },
-                // { key: "users", value: _roomList[i].users.length },
+                { key: "id", value: room.id },
+                { key: "title", value: room.title },
+                // { key: "limit", value: room.limit },
+                // { key: "current", value: room.current },
+                // { key: "users", value: room.users.length },
                 { key: "active", value: active },
             ]
 
+
+            /*
+            내가 들어간 방은 room-entered
+            내가 들어가있지 않은 방은 room-not-entered임.
+            table의 body 클래스명이 소속 여부에 따라 달라지니까 커스터마이징 하려면 css를 고치면 됨. 
+            */
+            if (room.users.indexOf(Number(this.props.userId)) != -1) {
+                var rowClassname = "room-entered"
+            }
+            else {
+                var rowClassname = "room-not-entered"
+            }
             content.push(
-                <Table.Body key={i.toString() + "table"}>
+                <Table.Body key={i.toString() + "table"} className={rowClassname}>
                     <Table.Row key={i.toString() + "row"}>
                         {row.map((value) => <Table.Cell key={value.key + i}> <p className="table-cell-text">{value.value} </p> </Table.Cell>)}
                     </Table.Row>
@@ -104,8 +117,8 @@ export default class Lobby extends Component {
                                 <Table.HeaderCell>id</Table.HeaderCell>
                                 <Table.HeaderCell>title</Table.HeaderCell>
                                 {/* <Table.HeaderCell>host</Table.HeaderCell>
-                                <Table.HeaderCell>current</Table.HeaderCell> */}
-                                {/* <Table.HeaderCell>users</Table.HeaderCell> */}
+                                <Table.HeaderCell>current</Table.HeaderCell> */
+                                /* <Table.HeaderCell>users</Table.HeaderCell> */}
                                 <Table.HeaderCell>JOIN</Table.HeaderCell>
                             </Table.Row>
                         </Table.Header>

--- a/bubblit/assets/js/Component/Lobby.js
+++ b/bubblit/assets/js/Component/Lobby.js
@@ -42,7 +42,6 @@ export default class Lobby extends Component {
                 active = (
                     <Link to="/room"><Button secondary key={"active" + i} action={{ index: i }} onClick={function (e, data) {
                         var room_id = _roomList[data.action.index].id;
-                        // [TODO] enterRoom 대신 room_id만 set해주는 redux 함수를 만들어야 할듯.
                         this.props.setRoomID(room_id);
                     }.bind(this)}>join</Button>
                     </Link>

--- a/bubblit/assets/js/Component/Room.js
+++ b/bubblit/assets/js/Component/Room.js
@@ -14,8 +14,70 @@ export default class Chat extends Component {
             shareSpace_width: window.innerWidth * 0.5,
             shareSpace_height: 0.85,
         }
+
+        let channelinit = async () => {
+            await this.props.enterRoom(this.props.current_room_id)
+            await this.channelInitialize();
+        }
+
+        channelinit()
     }
 
+    lobbyRedirect() {
+        alert(response, "방에 접속할 수 없습니다. 로비로 이동합니다.")
+        // 대충 로비로 리다이렉트 시켜주는 코드 쓰기
+        // this.props.history.
+    }
+
+    channelInitialize = () => {
+        this.props.channel.join()
+            .receive('ok', this.onReceiveOk.bind(this))
+            .receive('error', response => { console.log('Unable to join', response) });
+    }
+
+    onReceiveOk(response) {
+        console.log('joined successfully at ' + response)
+        this.props.channel.on('room_after_join', payload => {
+            this.props.setHistory(payload);
+            this.props.initializeRoomHistory(payload);
+        })
+        this.props.channel.on('user_join', payload => {
+            console.log('user_join', payload);
+            this.props.userJoin(payload.user_id, payload.user_name);
+        })
+        this.props.channel.on("new_msg", payload => {
+            let user_id = payload['user_id'];
+            let msg = payload['body'];
+
+            this.props.addMessage(payload['user_id'], payload['body']);
+        })
+        this.props.channel.on("presence_state", state => {
+            this.state.presences = Presence.syncState(this.state.presences, state)
+            console.log("presence_state", this.state.presences)
+        })
+        this.props.channel.on("presence_diff", diff => {
+            this.state.presences = Presence.syncDiff(this.state.presences, diff)
+            console.log("presence_diff", this.state.presences)
+        })
+
+    }
+
+
+    headerRender() {
+        if (this.props.roomInfo == undefined) {
+            return <p>Loading...</p>
+        }
+        else {
+            return <Header className='room-header' as='h1' size='huge'>
+                <Icon name='rocketchat' size='huge' />
+        Room '{this.props.roomInfo.room_title}'
+        </Header>
+        }
+    }
+
+    componentWillUnmount() {
+        this.props.exitRoom(this.props.channel)
+    }
     // ResizableBox에 초기 사이즈(width, height)는 숫자만 받음 => %값으로 줄 수 없음.
     // 따라서, window 창 크기를 계산해서 직접 %를 계산해서 줘야 할듯.
     // Grid가 사실상 유명무실해서 실제로 사용하기 쉽도록 사이즈 맞춤. 
@@ -27,7 +89,7 @@ export default class Chat extends Component {
         return (
             <div>
                 <div className='room' >
-                    <Header className='room-header' as='h1' size='huge'><Icon name='rocketchat' size='huge' />Room '{this.props.roomTitle}'</Header>
+                    {this.headerRender()}
                     <Grid columns={2}>
                         <Grid.Column>
                             <Rnd

--- a/bubblit/assets/js/Component/Room.js
+++ b/bubblit/assets/js/Component/Room.js
@@ -15,6 +15,7 @@ class Room extends Component {
             userID: 1,
             shareSpace_width: window.innerWidth * 0.5,
             shareSpace_height: 0.85,
+            isEnter: false
         }
 
         let channelinit = async () => {
@@ -27,8 +28,6 @@ class Room extends Component {
 
     lobbyRedirect = () => {
         alert("방에 접속할 수 없습니다. 로비로 이동합니다.")
-        // 대충 로비로 리다이렉트 시켜주는 코드 쓰기
-        this.props.exitRoom()
         this.props.history.push('/')
     }
 
@@ -43,6 +42,9 @@ class Room extends Component {
 
     onReceiveOk(response) {
         console.log('joined successfully at ' + response)
+        this.setState({
+            isEnter: true
+        })
         this.props.channel.on('room_after_join', payload => {
             this.props.setHistory(payload);
             this.props.initializeRoomHistory(payload);
@@ -91,37 +93,44 @@ class Room extends Component {
 
     // React RND로 모듈 바꿈, minwidth, maxwidth를 현재 창 크기의 비율로 맞추고싶은데 우선 놔둠
 
+    // <p>Loading...</p> 부분은 전부 나중에 로딩아이콘 같은걸로 바꾸면 됨(깔끔한 디자인 원하면)
     render() {
-        return (
-            <div>
-                <div className='room' >
-                    {this.headerRender()}
-                    <Grid columns={2}>
-                        <Grid.Column>
-                            <Rnd
-                                className='tab'
-                                disableDragging
-                                minWidth={window.innerWidth * 0.3}
-                                maxWidth={window.innerWidth * 0.6}
-                                default={{
-                                    x: 0,
-                                    y: 0,
-                                    width: window.innerWidth * 0.5,
-                                    height: window.innerHeight * 0.85,
-                                }}
-                                height={this.state.shareSpace_height}
-                            >
-                                <ShareSpace></ShareSpace>
+        if (!this.state.isEnter) {
+            return <p>Loading...</p>
+        }
+        else {
+            return (
+                <div>
+                    <div className='room' >
+                        {this.headerRender()}
+                        <Grid columns={2}>
+                            <Grid.Column>
+                                <Rnd
+                                    className='tab'
+                                    disableDragging
+                                    minWidth={window.innerWidth * 0.3}
+                                    maxWidth={window.innerWidth * 0.6}
+                                    default={{
+                                        x: 0,
+                                        y: 0,
+                                        width: window.innerWidth * 0.5,
+                                        height: window.innerHeight * 0.85,
+                                    }}
+                                    height={this.state.shareSpace_height}
+                                >
+                                    <ShareSpace></ShareSpace>
 
-                            </Rnd>
-                        </Grid.Column>
-                        <Grid.Column>
-                            <ChatModule></ChatModule>
-                        </Grid.Column>
-                    </Grid>
-                </div>
-            </div >
-        )
+                                </Rnd>
+                            </Grid.Column>
+                            <Grid.Column>
+                                <ChatModule></ChatModule>
+                            </Grid.Column>
+                        </Grid>
+                    </div>
+                </div >
+            )
+        }
+
     }
 }
 

--- a/bubblit/assets/js/Component/Room.js
+++ b/bubblit/assets/js/Component/Room.js
@@ -3,10 +3,12 @@ import { Grid, Header, Icon, Segment } from 'semantic-ui-react'
 import { Rnd } from 'react-rnd'
 import ChatModule from '../Container/ChatModule'
 import ShareSpace from '../Container/ShareSpace'
+import { Presence } from "phoenix"
 import '../../css/room.css'
+import { withRouter } from 'react-router-dom'
 
 
-export default class Chat extends Component {
+class Room extends Component {
     constructor(props) {
         super(props);
         this.state = {
@@ -23,16 +25,20 @@ export default class Chat extends Component {
         channelinit()
     }
 
-    lobbyRedirect() {
-        alert(response, "방에 접속할 수 없습니다. 로비로 이동합니다.")
+    lobbyRedirect = () => {
+        alert("방에 접속할 수 없습니다. 로비로 이동합니다.")
         // 대충 로비로 리다이렉트 시켜주는 코드 쓰기
-        // this.props.history.
+        this.props.exitRoom()
+        this.props.history.push('/')
     }
 
     channelInitialize = () => {
         this.props.channel.join()
             .receive('ok', this.onReceiveOk.bind(this))
-            .receive('error', response => { console.log('Unable to join', response) });
+            .receive('error', response => {
+                console.log('Unable to join', response)
+                this.lobbyRedirect()
+            });
     }
 
     onReceiveOk(response) {
@@ -76,7 +82,7 @@ export default class Chat extends Component {
     }
 
     componentWillUnmount() {
-        this.props.exitRoom(this.props.channel)
+        this.props.exitRoom()
     }
     // ResizableBox에 초기 사이즈(width, height)는 숫자만 받음 => %값으로 줄 수 없음.
     // 따라서, window 창 크기를 계산해서 직접 %를 계산해서 줘야 할듯.
@@ -118,3 +124,5 @@ export default class Chat extends Component {
         )
     }
 }
+
+export default withRouter(Room)

--- a/bubblit/assets/js/Component/ShareSpace.js
+++ b/bubblit/assets/js/Component/ShareSpace.js
@@ -15,7 +15,6 @@ export default class ShareSpace extends Component {
             mediaurl: '',
             mediaPlayTime: '',
             mediaIsPlay: true,
-            channel: this.props.channel,
             tabIndex: 0
         }
     }
@@ -114,7 +113,7 @@ export default class ShareSpace extends Component {
 
         let logContent =
             <Tab.Pane className="outerfit">
-                <LogPanel history={this.props.history} users={this.props.users} />
+                <LogPanel roomInfo={this.props.roomInfo} users={this.props.users} />
             </Tab.Pane>
 
         let imgContent =

--- a/bubblit/assets/js/Component/ShareSpaceComponent/LogPanel.js
+++ b/bubblit/assets/js/Component/ShareSpaceComponent/LogPanel.js
@@ -26,6 +26,10 @@ export default class LogPanel extends Component {
 
     historyRenderer() {
         let contents = [];
+        if (this.props.history == undefined) {
+            return [];
+        }
+
         if (this.props.history.bubble_history == undefined) {
             return [];
         }

--- a/bubblit/assets/js/Component/ShareSpaceComponent/LogPanel.js
+++ b/bubblit/assets/js/Component/ShareSpaceComponent/LogPanel.js
@@ -25,36 +25,36 @@ export default class LogPanel extends Component {
     }
 
     historyRenderer() {
+        console.log("logpanel's history: ", this.props.roomInfo.bubble_history);
+        console.log('in history users: ', this.props.roomInfo.users);
         let contents = [];
-        if (this.props.history == undefined) {
+        if (this.props.roomInfo == undefined) {
             return [];
         }
 
-        if (this.props.history.bubble_history == undefined) {
+        if (this.props.roomInfo.bubble_history == undefined) {
             return [];
         }
-        if (this.props.users === undefined) {
+        if (this.props.roomInfo.users === undefined) {
             return [];
         }
-        // this.props.history.bubble_history.forEach(element => {
-        //     contents.push(
-        //         <Comment key={element.id}>
-        //             <Comment.Content>
-        //                 <Comment.Author as='a'>{this.props.users[element.user_id].name}</Comment.Author>
-        //                 <Comment.Metadata>
-        //                     <div>{element.inserted_at}</div>
-        //                 </Comment.Metadata>
-        //                 <Comment.Text>{element.content}</Comment.Text>
-        //             </Comment.Content>
-        //         </Comment>
-        //     );
-        // })
+        this.props.roomInfo.bubble_history.forEach(element => {
+            contents.push(
+                // <Comment key={element.id}>
+                //     <Comment.Content>
+                //         <Comment.Author as='a'>{this.props.roomInfo.users[element.user_id].name}</Comment.Author>
+                //         <Comment.Metadata>
+                //             <div>{element.inserted_at}</div>
+                //         </Comment.Metadata>
+                //         <Comment.Text>{element.content}</Comment.Text>
+                //     </Comment.Content>
+                // </Comment>
+            );
+        })
         return contents;
     }
 
     render() {
-        // console.log("logpanel's history: ", this.props.history.bubble_history);
-        // console.log('in history users: ', this.props.users);
         return (
             < div >
                 <Scrollbars

--- a/bubblit/assets/js/Component/ShareSpaceComponent/LogPanel.js
+++ b/bubblit/assets/js/Component/ShareSpaceComponent/LogPanel.js
@@ -38,19 +38,19 @@ export default class LogPanel extends Component {
         if (this.props.roomInfo.users === undefined) {
             return [];
         }
-        this.props.roomInfo.bubble_history.forEach(element => {
-            contents.push(
-                // <Comment key={element.id}>
-                //     <Comment.Content>
-                //         <Comment.Author as='a'>{this.props.roomInfo.users[element.user_id].name}</Comment.Author>
-                //         <Comment.Metadata>
-                //             <div>{element.inserted_at}</div>
-                //         </Comment.Metadata>
-                //         <Comment.Text>{element.content}</Comment.Text>
-                //     </Comment.Content>
-                // </Comment>
-            );
-        })
+        // this.props.roomInfo.bubble_history.forEach(element => {
+        //     contents.push(
+        //         // <Comment key={element.id}>
+        //         //     <Comment.Content>
+        //         //         <Comment.Author as='a'>{this.props.roomInfo.users[element.user_id].name}</Comment.Author>
+        //         //         <Comment.Metadata>
+        //         //             <div>{element.inserted_at}</div>
+        //         //         </Comment.Metadata>
+        //         //         <Comment.Text>{element.content}</Comment.Text>
+        //         //     </Comment.Content>
+        //         // </Comment>
+        //     );
+        // })
         return contents;
     }
 

--- a/bubblit/assets/js/Container/ChatModule.js
+++ b/bubblit/assets/js/Container/ChatModule.js
@@ -4,43 +4,18 @@ import { connect } from 'react-redux'
 function mapReduxStateToReactProps(state) {
     return {
         channel: state.channel,
-        userName: state.userName,
-        history: state.history,
-        current_room_id: state.current_room_id,
         roomInfo: state.roomInfo,
     }
 }
 
 function mapReduxDispatchToReactProps(dispatch) {
     return {
-        exitRoom: function (channel) {
-            //channel.push('new_msg', { body: '테스트 메세지임니담' });
-            // ok일때는 정상적으로 끝난 거니까 놔두고, 에러일때만 콘솔로그 띄우도록 했음. 
-            channel.leave().receive('error', () => console.log('error occured!'));
-            dispatch({ type: 'EXIT' })
-        },
         sendChat: function (channel, msg) {
             channel.push('new_msg', { body: msg });
         },
         appendHistory: function (new_history) {
             dispatch({ type: 'INSERT_HISTORY', history: new_history });
         },
-        setHistory: function (payload) {
-            dispatch({ type: 'SET_HISTORY', history: payload })
-        },
-
-        // 리팩토링된 함수
-        addMessage: function (user_id, body) {
-            dispatch({
-                type: 'ADD_MESSAGE',
-                user_id: user_id,
-                body: body,
-            })
-        },
-        userJoin: function (user_id, user_name) {
-            dispatch({ type: 'USER_JOIN', user_id: user_id, user_name: user_name })
-        },
-
     }
 }
 

--- a/bubblit/assets/js/Container/ChatModule.js
+++ b/bubblit/assets/js/Container/ChatModule.js
@@ -25,9 +25,6 @@ function mapReduxDispatchToReactProps(dispatch) {
         appendHistory: function (new_history) {
             dispatch({ type: 'INSERT_HISTORY', history: new_history });
         },
-        enterRoom: function (room_id) {
-            dispatch({ type: 'ENTER_CHAT', room_id: room_id })
-        },
         setHistory: function (payload) {
             dispatch({ type: 'SET_HISTORY', history: payload })
         },
@@ -39,15 +36,6 @@ function mapReduxDispatchToReactProps(dispatch) {
                 user_id: user_id,
                 body: body,
             })
-        },
-        initializeRoomHistory: function (payload) {
-            dispatch({
-                type: 'INITIALIZE_ROOM_INFO',
-                bubble_history: payload['bubble_history'],
-                room_users: payload['room_users'],
-                tab_action_history: payload['tab_action_history'],
-                users: payload['users'],
-            });
         },
         userJoin: function (user_id, user_name) {
             dispatch({ type: 'USER_JOIN', user_id: user_id, user_name: user_name })

--- a/bubblit/assets/js/Container/Lobby.js
+++ b/bubblit/assets/js/Container/Lobby.js
@@ -5,6 +5,7 @@ function mapReduxStateToReactProps(state) {
     return {
         roomList: state.roomList,
         userName: state.userName,
+        userId: state.userId,
         current_room_id: state.current_room_id
     }
 }
@@ -17,8 +18,8 @@ function mapReduxDispatchToReactProps(dispatch) {
         refreshRoomList: function (room_list) {
             dispatch({ type: 'REFRESH_ROOM_LIST', room_list: room_list })
         },
-        setUserName: function (userName) {
-            dispatch({ type: 'SET_USER_NAME', userName: userName })
+        setUserData: function (userName, userId) {
+            dispatch({ type: 'SET_USER_DATA', userName: userName, userId: userId })
         }
     }
 }

--- a/bubblit/assets/js/Container/Lobby.js
+++ b/bubblit/assets/js/Container/Lobby.js
@@ -11,8 +11,8 @@ function mapReduxStateToReactProps(state) {
 
 function mapReduxDispatchToReactProps(dispatch) {
     return {
-        enterRoom: function (room_id) {
-            dispatch({ type: 'ENTER_CHAT', room_id: room_id })
+        setRoomID: function (room_id) {
+            dispatch({ type: 'SET_ROOM_ID', room_id: room_id })
         },
         refreshRoomList: function (room_list) {
             dispatch({ type: 'REFRESH_ROOM_LIST', room_list: room_list })

--- a/bubblit/assets/js/Container/Room.js
+++ b/bubblit/assets/js/Container/Room.js
@@ -5,7 +5,11 @@ function mapReduxStateToReactProps(state) {
     return {
         chatRoom: state.chatRoom,
         chatDB: state.chatDB,
-        roomTitle: state.roomTitle
+        channel: state.channel,
+        userName: state.userName,
+        history: state.history,
+        current_room_id: state.current_room_id,
+        roomInfo: state.roomInfo,
     }
 }
 
@@ -13,7 +17,33 @@ function mapReduxDispatchToReactProps(dispatch) {
     return {
         exitRoom: function () {
             dispatch({ type: 'EXIT' });
-        }
+        },
+        enterRoom: function (room_id) {
+            dispatch({ type: 'ENTER_ROOM', room_id: room_id })
+        },
+        setHistory: function (payload) {
+            dispatch({ type: 'SET_HISTORY', history: payload })
+        },
+        addMessage: function (user_id, body) {
+            dispatch({
+                type: 'ADD_MESSAGE',
+                user_id: user_id,
+                body: body,
+            })
+        },
+        initializeRoomHistory: function (payload) {
+            dispatch({
+                type: 'INITIALIZE_ROOM_INFO',
+                bubble_history: payload['bubble_history'],
+                room_users: payload['room_users'],
+                tab_action_history: payload['tab_action_history'],
+                users: payload['users'],
+            });
+        },
+        userJoin: function (user_id, user_name) {
+            dispatch({ type: 'USER_JOIN', user_id: user_id, user_name: user_name })
+        },
+
     }
 }
 

--- a/bubblit/assets/js/Container/ShareSpace.js
+++ b/bubblit/assets/js/Container/ShareSpace.js
@@ -12,9 +12,7 @@ function mapReduxStateToReactProps(state) {
 
 function mapReduxDispatchToReactProps(dispatch) {
     return {
-        // enterRoom: function (room_id) {
-        //     dispatch({ type: 'ENTER_CHAT', room_id: room_id })
-        // },
+
     }
 }
 

--- a/bubblit/assets/js/Container/ShareSpace.js
+++ b/bubblit/assets/js/Container/ShareSpace.js
@@ -5,8 +5,8 @@ function mapReduxStateToReactProps(state) {
     return {
         current_room_id: state.current_room_id,
         channel: state.channel,
-        history: state.history,
         users: state.users,
+        roomInfo: state.roomInfo
     }
 }
 

--- a/bubblit/assets/js/store.js
+++ b/bubblit/assets/js/store.js
@@ -51,6 +51,7 @@ const init_state = {
     channel: '',
     roomTitle: '',
     userName: '',
+    userId: 0,
     roomList: [],
     current_room_id: 0,
     users: '',
@@ -117,8 +118,8 @@ export default createStore(function (state, action) {
         return { ...state, history: action.history }
     }
 
-    if (action.type === 'SET_USER_NAME') {
-        return { ...state, userName: action.userName }
+    if (action.type === 'SET_USER_DATA') {
+        return { ...state, userName: action.userName, userId: action.userId }
     }
 
     // 리팩토링됨

--- a/bubblit/assets/js/store.js
+++ b/bubblit/assets/js/store.js
@@ -104,6 +104,7 @@ export default createStore(function (state, action) {
     }
     if (action.type === 'EXIT') {
         //channel 구독해지 및 state 초기화
+        state.channel.leave()
         return { ...state, contents: [[], [], [], [], []], participants: [] }
     }
     if (action.type === 'SET_HISTORY') {
@@ -140,7 +141,8 @@ export default createStore(function (state, action) {
         action.bubble_history.forEach(element => {
             addMessageInBubbleHistory(init_bubble_history, element)
         })
-
+        console.log('방정보받은거')
+        console.dir(action)
         modifiedRoomInfo.bubble_history = init_bubble_history;
         modifiedRoomInfo.tab_action_history = action.tab_action_history;
         modifiedRoomInfo.room_users = action.room_users;

--- a/bubblit/assets/js/store.js
+++ b/bubblit/assets/js/store.js
@@ -96,6 +96,7 @@ export default createStore(function (state, action) {
     }
     if (action.type === 'ENTER_ROOM') {
         return {
+            ...state,
             channel: state.socket.channel('room:' + action.room_id, { nickname: state.userName })
         }
     }

--- a/bubblit/assets/js/store.js
+++ b/bubblit/assets/js/store.js
@@ -50,9 +50,7 @@ const init_state = {
     // 채널은 아래의 'SET_ROOM_ID' dispatch때 생성해줌
     channel: '',
     roomTitle: '',
-    userName: 'kynel',
-
-    // { id: 0, title: '1st Room', host: 'kynel', isPrivate: 'O', limit: 10, current: 6 },
+    userName: '',
     roomList: [],
     current_room_id: 0,
     users: '',

--- a/bubblit/lib/bubblit/room/room_monitor.ex
+++ b/bubblit/lib/bubblit/room/room_monitor.ex
@@ -105,7 +105,9 @@ defmodule Bubblit.Room.Monitor do
       bubble_history: Map.get(state, :history, []),
       room_users: state[:room_record].users,
       users: Map.get(state, :users, []),
-      tab_action_history: Map.get(state, :tab_action_dic, %{})
+      tab_action_history: Map.get(state, :tab_action_dic, %{}),
+      # 작성중
+      room_title: state[:title]
     }
   end
 

--- a/bubblit/lib/bubblit_web/templates/layout/app.html.eex
+++ b/bubblit/lib/bubblit_web/templates/layout/app.html.eex
@@ -22,6 +22,7 @@
         <ul id="nav-mobile" class="right hide-on-med-and-down">
             <%= if signed_in?(@conn) do %>
               <li><a id="current-username" class="dropdown-trigger" href="#!" data-target="user-actions"><%=@current_user.name %></a></li>
+              <li><a id="current-userid"data-target="user-actions"><%=@current_user.id %></a></li>
             <% end %>
         </ul>
       </div>


### PR DESCRIPTION
1. 내가 속한 방 표시함. 디자인 수정은 알아서 하면 됨.

2. 방 입장 관련 로직은 chatmodule이나 lobby에서 들고있을 내용이 아님. 로직을 전부 room.js로 옮겼음. join 버튼은 해당 방 번호 받아서 리덕스에 저장하는 역할만 하고, chatmodule은 채팅 보내기 같은 채팅과 직접 관련있는 기능만 담당함.

3. 이름같은거 불편해서 좀 고침

4. channel.leave 없이 그냥 channel 객체만 고쳐쓰고 있길래 exit 할 때 channel.leave 하도록 했음.

5. **리팩토링 완료됐다면 이제 store에 필요없는 state들을 다 지워주세요.....**
