### PR TITLE
#101 탭 액션 제어 기능 추가

### DIFF
--- a/bubblit/assets/js/Component/ShareSpace.js
+++ b/bubblit/assets/js/Component/ShareSpace.js
@@ -12,6 +12,7 @@ export default class ShareSpace extends Component {
         super(props);
         this.state = {
             action_history: [],
+            restrict_control: "true",
             imageurl: '',
             docurl: '',
             mediaurl: '',
@@ -93,6 +94,10 @@ export default class ShareSpace extends Component {
                     tabIndex: tabs['media']
                 })
                 return { mediaIsPlay: (body === 'true') }
+            case "restrict_control":
+                return {
+                    restrict_control: body
+                }
         }
     }
 
@@ -172,6 +177,7 @@ export default class ShareSpace extends Component {
 
         return (
             <div className="sharespace-div">
+                <div>{this.state.restrict_control}</div>
                 <Button key={"underMyControl"} onClick={function (e, data) {
                     this.sendTabAction("restrict_control", "true")
                 }.bind(this)}>SetControl</Button>

--- a/bubblit/assets/js/Component/ShareSpace.js
+++ b/bubblit/assets/js/Component/ShareSpace.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react'
-import { Tab } from 'semantic-ui-react'
+import { Tab, Button } from 'semantic-ui-react'
 import MediaPanel from './ShareSpaceComponent/MediaPanel'
 import DocsPanel from './ShareSpaceComponent/googledocs'
 import ImagePanel from './ShareSpaceComponent/shareimage'
@@ -172,6 +172,12 @@ export default class ShareSpace extends Component {
 
         return (
             <div className="sharespace-div">
+                <Button key={"underMyControl"} onClick={function (e, data) {
+                    this.sendTabAction("restrict_control", "true")
+                }.bind(this)}>SetControl</Button>
+                <Button key={"underMyUnsetControl"} onClick={function (e, data) {
+                    this.sendTabAction("restrict_control", "false")
+                }.bind(this)}>UnSetControl</Button>
                 <Tab className="outerfit"
                     menu={{ size: 'huge', color: 'blue', inverted: true, attatched: "false", tabular: false }}
                     panes={panes}

--- a/bubblit/assets/js/Component/ShareSpaceComponent/shareimage.js
+++ b/bubblit/assets/js/Component/ShareSpaceComponent/shareimage.js
@@ -53,7 +53,7 @@ export default class ImagePanel extends Component {
                         console.log(response);
                     })
                     .catch(function (error) {
-                        console.log(error);
+                        console.log("error when upload image.", error.response.data);
                     })
             })
             .catch(function (error) {

--- a/bubblit/lib/bubblit/application.ex
+++ b/bubblit/lib/bubblit/application.ex
@@ -24,6 +24,8 @@ defmodule Bubblit.Application do
     # for other strategies and supported options
     opts = [strategy: :one_for_one]
 
+    Ets.init()
+
     Util.log("#{__MODULE__} 이 시작됩니다.")
 
     Supervisor.start_link(children, opts)

--- a/bubblit/lib/bubblit/room/room_monitor.ex
+++ b/bubblit/lib/bubblit/room/room_monitor.ex
@@ -14,6 +14,17 @@ defmodule Bubblit.Room.Monitor do
 
     tab_actinos = Bubblit.Db.get_room_actions(room_id) |> Enum.reverse()
 
+    if restrict_action = Enum.find(tab_actinos, fn x -> x.type == "restrict_control" end) do
+      Util.log("#{room_id} restrict_action.param #{restrict_action.param}")
+
+      if restrict_action.param == "true" do
+        Ets.set_room_control_restricted(room_id)
+      end
+    else
+      Util.log("#{room_id} restrict_action None")
+      Ets.unset_room_control_restricted(false)
+    end
+
     room_member_user =
       room_record.users
       |> Enum.map(fn x -> Bubblit.Accounts.get_user!(x) end)

--- a/bubblit/lib/bubblit/shared/ets.ex
+++ b/bubblit/lib/bubblit/shared/ets.ex
@@ -1,19 +1,27 @@
 defmodule Ets do
   require Logger
 
-  def init(msg) do
+  def init() do
+    Util.log("Room ets init")
     # 우선 전부 public
-    table = :ets.new(:room_info, [:set, :public])
+    _table = :ets.new(:room_info, [:set, :public, :named_table])
   end
 
-  def add_room_info(room) do
-    :ets.insert(:user_lookup, {room.id, room})
+  def set_room_control_restricted(room_id) do
+    Util.log("Room #{room_id} set room control restricted.")
+    # true는 의미 없음
+    :ets.insert(:room_info, {room_id, true})
   end
 
-  def add_room_info(room) do
-    case :ets.lookup(:user_lookup, "doomspork") do
-      [room] -> room
-      [] -> nil
+  def unset_room_control_restricted(room_id) do
+    Util.log("Room #{room_id} unset room control restricted.")
+    :ets.delete(:room_info, room_id)
+  end
+
+  def room_control_restricted?(room_id) do
+    case :ets.lookup(:room_info, room_id) do
+      [_room] -> true
+      [] -> false
     end
   end
 end

--- a/bubblit/lib/bubblit_web/controllers/room_image_controller.ex
+++ b/bubblit/lib/bubblit_web/controllers/room_image_controller.ex
@@ -2,8 +2,8 @@ defmodule BubblitWeb.RoomImageController do
   use BubblitWeb, :controller
   require Util
 
-  def new(conn, %{"room_id" => room_id, "file" => file} = _param) do
-    image_file_path = Path.absname("uploaded")
+  def new(conn, %{"room_id" => [room_id], "file" => file} = _param) do
+    {room_id, ""} = Integer.parse(room_id)
 
     if File.exists?(image_file_path) == False and File.dir?(image_file_path) do
       :ok = File.mkdir(image_file_path)
@@ -29,6 +29,6 @@ defmodule BubblitWeb.RoomImageController do
 
   def get_room_image_path(room_id) do
     image_file_path = Path.absname("uploaded")
-    "#{image_file_path}/room_#{(room_id)}_image"
+    "#{image_file_path}/room_#{room_id}_image"
   end
 end


### PR DESCRIPTION
호스트 변경시에 문제가 많을 것으로 예상. 이유는 host 판단을 room_record 갱신으로 해주고 있기 때문임. 어렵다 어려워

## ets를 이용해서 룸의 탭 액션 제어가  설정되어있는지 확인한다.

매번 db에 접근해서 가져오긴 비용이 크고, 애초에 db에 저장안한다.
탭 액션 제어도 `tab_action의 일종`으로 취급함. 그래서 서버 뜰 때 tab_aciton에 있는 마지막 탭 액션 제어 액션을 보고 보고 현재 방의 status를 결정한다.

## sharespace에 임시로 표시하게 해줌.

https://github.com/Capstone-R-99/BubbLit/pull/102/commits/25a7edcd30e10647d5e6c2aebaf8a8f0a641b65e
https://github.com/Capstone-R-99/BubbLit/pull/102/commits/be19c7d59d40a85b46b4f3e5378b0343393244ea

이거 두개 보면 됨.

## 이미지 업로드에 대해서 다르게 판단하고 있음

어쩔 수 없다. 통로가 달라서. 이 통로를 합치는게 나의 꿈이다.
