### PR TITLE
#112 이미지 공유 기능 방식 개선. 이미지 히스토리 구현.

### DIFF
--- a/bubblit/assets/js/Component/ShareSpace.js
+++ b/bubblit/assets/js/Component/ShareSpace.js
@@ -92,7 +92,7 @@ export default class ShareSpace extends Component {
                 this.setState({
                     tabIndex: tabs['image']
                 })
-                return { imageurl: "api/room/get_image/" + this.props.current_room_id + "?" + new Date().getTime() }
+                return { imageurl: "api/room/get_image/" + body }
             case "media_link":
                 this.setState({
                     tabIndex: tabs['media']
@@ -131,10 +131,9 @@ export default class ShareSpace extends Component {
         this.props.channel.push("tab_action", { type: type, body: body })
     }
 
-    handleImageUploadSuccess() {
-        // Glurjar 적용중이라 실제 작동은 안하는듯
-        console.log("handleImageUploadSuccess")
-        this.sendTabAction("img_refreshed", "")
+    handleImageUploadSuccess(file_name) {
+        console.log("handleImageUploadSuccess", file_name)
+        this.sendTabAction("img_refreshed", file_name)
     }
 
     handleTabChange(e, data) {

--- a/bubblit/assets/js/Component/ShareSpaceComponent/ActionLogPanel.js
+++ b/bubblit/assets/js/Component/ShareSpaceComponent/ActionLogPanel.js
@@ -39,7 +39,7 @@ export default class ActionLogPanel extends Component {
         //JS는 갓언어라 String format이 없다.
         switch (type) {
             case "img_refreshed":
-                return name + "님이 이미지를 공유하였습니다";
+                return <div>{name + "님이 이미지를 공유하였습니다"} <a href={"api/room/get_image/" + param} target="_blank">보기</a> </div>;
             case "media_link":
                 return name + "님이 " + param + " 미디어를 공유하였습니다.";
             case "media_current_play":

--- a/bubblit/assets/js/Component/ShareSpaceComponent/shareimage.js
+++ b/bubblit/assets/js/Component/ShareSpaceComponent/shareimage.js
@@ -16,12 +16,6 @@ export default class ImagePanel extends Component {
         }
     }
 
-
-    handleImageUrlClick(event) {
-        this.state.broadcastAction(this.state.imageurlinput)
-
-    }
-
     OnPaste(file) {
         if (file.images.length <= 0) {
             return;
@@ -49,7 +43,8 @@ export default class ImagePanel extends Component {
 
                 uploadFileRequest(room_id, blob)
                     .then(function (response) {
-                        self.state.broadcastAction();
+                        console.log("image upload success", response);
+                        self.state.broadcastAction(response.data.file_name);
                         console.log(response);
                     })
                     .catch(function (error) {

--- a/bubblit/lib/bubblit_web/controllers/room_image_controller.ex
+++ b/bubblit/lib/bubblit_web/controllers/room_image_controller.ex
@@ -21,15 +21,14 @@ defmodule BubblitWeb.RoomImageController do
       # file_name = Path.basename(file.path)
       # extention = MIME.extensions(file.content_type) |> List.first()
 
-      Util.log(
-        "#{user_id} uploaded image. save file from #{file.path} -> to #{
-          get_room_image_path(room_id)
-        }"
-      )
+      file_name = "#{DateTime.to_unix(DateTime.utc_now(), :millisecond)}_#{room_id}_#{user_id}"
+      saved_path = get_image_by_file_path(file_name)
 
-      case File.cp(file.path, get_room_image_path(room_id)) do
+      Util.log("#{user_id} uploaded image. save file from #{file.path} -> to #{saved_path}")
+
+      case File.cp(file.path, saved_path) do
         :ok ->
-          json(conn, "Uploaded #{file.filename}")
+          json(conn, %{file_name: file_name})
 
         {:error, msg} ->
           Util.log_error("#{user_id} uploaded image failed. to #{get_room_image_path(room_id)}")
@@ -45,8 +44,21 @@ defmodule BubblitWeb.RoomImageController do
     send_file(conn, 200, get_room_image_path(room_id))
   end
 
+  # 권한 체크 필요.
+  def show(conn, %{"file_name" => file_name} = _param) do
+    send_file(conn, 200, get_image_by_file_path(file_name))
+  end
+
   def get_room_image_path(room_id) do
     image_file_path = Path.absname("uploaded")
+
     "#{image_file_path}/room_#{room_id}_image"
   end
+
+  def get_image_by_file_path(file_path) do
+    image_file_path = Path.absname("uploaded")
+
+    "#{image_file_path}/#{file_path}"
+  end
+
 end

--- a/bubblit/lib/bubblit_web/router.ex
+++ b/bubblit/lib/bubblit_web/router.ex
@@ -51,7 +51,7 @@ defmodule BubblitWeb.Router do
     resources "/room/make", RoomController, except: [:index, :show]
 
     post "/room/upload_image/*room_id", RoomImageController, :new
-    get "/room/get_image/*room_id", RoomImageController, :show
+    get "/room/get_image/*file_name", RoomImageController, :show
   end
 
   defp put_user_token(conn, _) do


### PR DESCRIPTION
 - 방 전용 이미지파일을 업로드하는게 아니라, 이미지파일을 업로드 한 다음 그 식별자를 받아오는 식으로 변경
 - 따라서 그 받아온 식별자(file_name)을 tab_action에 넣어서 보내는 식으로 변경
 - 따라서 history 기능도 구현.

@Kynel 은 actionLogHistory에 추가된 코드만 보면 되고
@RE-A 는 딱히 바뀐거 없을듯.